### PR TITLE
Implement padding mask

### DIFF
--- a/dataloader/base_dataloader.py
+++ b/dataloader/base_dataloader.py
@@ -6,3 +6,4 @@ class BaseDataloader:
         self.coords = torch.tensor(data["coords"], dtype=torch.float32)    # (B, N, 3)
         self.outputs = torch.tensor(data["outputs"], dtype=torch.float32)  # (B, N, 4/5)
         self.params = torch.tensor(data["params"], dtype=torch.float32)    # (B, 1)
+        self.mask = torch.tensor(data["mask"], dtype=torch.bool)

--- a/dataloader/methods_dataloader.py
+++ b/dataloader/methods_dataloader.py
@@ -8,7 +8,7 @@ class MethodsDataloader:
         return self.coords.shape[0]  # number of samples
 
     def __getitem__(self, idx):
-        return self.coords[idx], self.params[idx], self.outputs[idx]
+        return self.coords[idx], self.params[idx], self.outputs[idx], self.mask[idx]
 
 
 
@@ -16,13 +16,18 @@ class MethodsDataloader:
         coords = self.coords
         outputs = self.outputs
         params = self.params
+        mask = self.mask
 
         # Split data into training and testing sets
         indices = np.arange(coords.shape[0])
         train_indices, test_indices = train_test_split(indices, test_size=test_size, shuffle=shuffle, random_state=42)
 
-        train_dataset = torch.utils.data.TensorDataset(coords[train_indices], params[train_indices], outputs[train_indices])
-        test_dataset = torch.utils.data.TensorDataset(coords[test_indices], params[test_indices], outputs[test_indices])
+        train_dataset = torch.utils.data.TensorDataset(
+            coords[train_indices], params[train_indices], outputs[train_indices], mask[train_indices]
+        )
+        test_dataset = torch.utils.data.TensorDataset(
+            coords[test_indices], params[test_indices], outputs[test_indices], mask[test_indices]
+        )
 
         train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
         test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)

--- a/preprocess/base_preprocess.py
+++ b/preprocess/base_preprocess.py
@@ -8,3 +8,4 @@ class BasePreprocess:
         self.npts_max = 0  # max elements determined based on data
         self.dimension = dimension
         self.lhs_applied = False
+        self.masks = []

--- a/preprocess/methods_preprocess.py
+++ b/preprocess/methods_preprocess.py
@@ -24,9 +24,22 @@ class MethodsPreprocess:
 
         self.npts_max = max(c.shape[0] for c in self.coords)
 
-        self.coords = [self._pad(c) for c in self.coords]
-        self.radii = [self._pad(r) for r in self.radii]
-        self.outputs = [self._pad(o) for o in self.outputs]
+        padded_coords = []
+        padded_radii = []
+        padded_outputs = []
+        self.masks = []
+        for c, r, o in zip(self.coords, self.radii, self.outputs):
+            c_pad, mask = self._pad(c)
+            r_pad, _ = self._pad(r)
+            o_pad, _ = self._pad(o)
+            padded_coords.append(c_pad)
+            padded_radii.append(r_pad)
+            padded_outputs.append(o_pad)
+            self.masks.append(mask)
+
+        self.coords = padded_coords
+        self.radii = padded_radii
+        self.outputs = padded_outputs
 
         # Normalize AFTER padding
         coords_flat = np.vstack(self.coords)
@@ -67,17 +80,24 @@ class MethodsPreprocess:
         return coords, outputs
     
     def _pad(self, arr):
-        return np.pad(arr, ((0, self.npts_max - arr.shape[0]), (0, 0)), mode="edge")
+        n_pad = self.npts_max - arr.shape[0]
+        mask = np.concatenate([
+            np.ones(arr.shape[0], dtype=bool),
+            np.zeros(n_pad, dtype=bool),
+        ])
+        padded = np.pad(arr, ((0, n_pad), (0, 0)), mode="edge")
+        return padded, mask
 
     def to_numpy(self):
         X_coords = np.stack(self.coords)
         Y_outputs = np.stack(self.outputs)
         G_params = np.stack(self.radii)[:, 0, :]  # extract 1 value per sample
-        return X_coords, Y_outputs, G_params
+        M_masks = np.stack(self.masks)
+        return X_coords, Y_outputs, G_params, M_masks
 
     def save(self):
-        X_coords, Y_outputs, G_params = self.to_numpy()
-        np.savez(self.output_path, coords=X_coords, outputs=Y_outputs, params=G_params,
+        X_coords, Y_outputs, G_params, M_masks = self.to_numpy()
+        np.savez(self.output_path, coords=X_coords, outputs=Y_outputs, params=G_params, mask=M_masks,
                 coords_mean=self.coords_mean,
                 coords_std=self.coords_std,
                 outputs_mean=self.outputs_mean,

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -10,8 +10,9 @@ def create_npz(tmp_path):
     coords = np.random.rand(4, 5, 3).astype(np.float32)
     outputs = np.random.rand(4, 5, 5).astype(np.float32)
     params = np.random.rand(4, 1).astype(np.float32)
+    mask = np.ones((4, 5), dtype=bool)
     path = tmp_path / "sample.npz"
-    np.savez(path, coords=coords, outputs=outputs, params=params)
+    np.savez(path, coords=coords, outputs=outputs, params=params, mask=mask)
     return path
 
 
@@ -21,16 +22,18 @@ def test_initialization(tmp_path):
     assert data.coords.shape == (4, 5, 3)
     assert data.outputs.shape == (4, 5, 5)
     assert data.params.shape == (4, 1)
+    assert data.mask.shape == (4, 5)
 
 
 def test_len_and_getitem(tmp_path):
     npz = create_npz(tmp_path)
     data = Data(str(npz))
     assert len(data) == 4
-    c, p, o = data[1]
+    c, p, o, m = data[1]
     assert c.shape == (5, 3)
     assert p.shape == (1,)
     assert o.shape == (5, 5)
+    assert m.shape == (5,)
 
 
 def test_get_dataloader(tmp_path):

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -86,16 +86,18 @@ def test_initial_state(preprocess):
     assert preprocess.radii == []
     assert preprocess.outputs == []
     assert preprocess.npts_max == 0
+    assert preprocess.masks == []
 
 
 def test_load_and_pad(preprocess):
     preprocess.load_and_pad()
     assert len(preprocess.coords) == 3
     assert preprocess.npts_max == TEST_SAMPLE_SIZE
-    for c, r, o in zip(preprocess.coords, preprocess.radii, preprocess.outputs):
+    for c, r, o, m in zip(preprocess.coords, preprocess.radii, preprocess.outputs, preprocess.masks):
         assert c.shape[0] == TEST_SAMPLE_SIZE
         assert r.shape[0] == TEST_SAMPLE_SIZE
         assert o.shape[0] == TEST_SAMPLE_SIZE
+        assert m.shape[0] == TEST_SAMPLE_SIZE
 
 
 def test_to_numpy_and_save(preprocess):
@@ -105,6 +107,7 @@ def test_to_numpy_and_save(preprocess):
     assert data["coords"].shape == (3, TEST_SAMPLE_SIZE, 3)
     assert data["outputs"].shape == (3, TEST_SAMPLE_SIZE, 5)
     assert data["params"].shape == (3, 1)
+    assert data["mask"].shape == (3, TEST_SAMPLE_SIZE)
 
     # arrays are normalized
     def check_norm(arr):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -10,7 +10,8 @@ def create_loaders():
     coords = torch.rand(4, 5, 3)
     params = torch.rand(4, 1)
     outputs = torch.rand(4, 5, 5)
-    dataset = torch.utils.data.TensorDataset(coords, params, outputs)
+    mask = torch.ones(4, 5, dtype=torch.bool)
+    dataset = torch.utils.data.TensorDataset(coords, params, outputs, mask)
     loader = torch.utils.data.DataLoader(dataset, batch_size=2)
     return loader
 

--- a/trainer/methods_trainer.py
+++ b/trainer/methods_trainer.py
@@ -14,14 +14,16 @@ class MethodsTrainer:
             self.model.train()
             total_samples = 0
 
-            for coords, params, targets in train_loader:
+            for coords, params, targets, mask in train_loader:
                 coords = coords.to(self.device)
                 params = params.to(self.device)
                 targets = targets.to(self.device)
+                mask = mask.to(self.device)
 
                 self.optimizer.zero_grad()
                 outputs = self.model(coords, params)
-                loss = self.criterion(outputs, targets)
+                diff = (outputs - targets) * mask.unsqueeze(-1)
+                loss = (diff ** 2).sum() / mask.sum()
                 loss.backward()
                 self.optimizer.step()
 
@@ -49,13 +51,15 @@ class MethodsTrainer:
         total_loss = 0.0
         total_samples = 0
         with torch.no_grad():
-            for coords, params, targets in dataloader:
+            for coords, params, targets, mask in dataloader:
                 coords = coords.to(self.device)
                 params = params.to(self.device)
                 targets = targets.to(self.device)
+                mask = mask.to(self.device)
 
                 outputs = self.model(coords, params)
-                loss = self.criterion(outputs, targets)
+                diff = (outputs - targets) * mask.unsqueeze(-1)
+                loss = (diff ** 2).sum() / mask.sum()
                 batch_size = targets.size(0)
                 total_loss += loss.item() * batch_size
                 total_samples += batch_size


### PR DESCRIPTION
## Summary
- return a mask from `Preprocess._pad` and save it
- load `mask` in `Data` and propagate it through dataloaders
- ignore padded values in `Trainer` during loss calculation
- update tests for the new mask behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848660b07488331b87261e29816f3a5