### PR TITLE
Fix padding logic for masking

### DIFF
--- a/preprocess/methods_preprocess.py
+++ b/preprocess/methods_preprocess.py
@@ -24,10 +24,7 @@ class MethodsPreprocess:
 
         self.npts_max = max(c.shape[0] for c in self.coords)
 
-        #pad all arrays to the maximum number of points
-        self.coords = [self._pad(c) for c in self.coords]
-        self.radii = [self._pad(r) for r in self.radii]
-        self.outputs = [self._pad(o) for o in self.outputs]
+        # pad all arrays to the maximum number of points
         padded_coords = []
         padded_radii = []
         padded_outputs = []
@@ -101,11 +98,13 @@ class MethodsPreprocess:
         return X_coords, Y_outputs, G_params, M_masks
 
     def save(self):
-        X_coords, Y_outputs, G_params = self.to_numpy()
-        np.savez(self.output_path,
+        X_coords, Y_outputs, G_params, M_masks = self.to_numpy()
+        np.savez(
+            self.output_path,
             coords=X_coords,           # shape: (num_samples, npts_max, 3)
             outputs=Y_outputs,         # shape: (num_samples, npts_max, output_dim)
             params=G_params,           # shape: (num_samples, 1)
+            mask=M_masks,
             coords_mean=self.coords_mean,     # shape: (3,)
             coords_std=self.coords_std,       # shape: (3,)
             outputs_mean=self.outputs_mean,   # shape: (output_dim,)
@@ -113,14 +112,6 @@ class MethodsPreprocess:
             radii_mean=self.radii_mean,       # shape: (1,)
             radii_std=self.radii_std          # shape: (1,)
         )
-        X_coords, Y_outputs, G_params, M_masks = self.to_numpy()
-        np.savez(self.output_path, coords=X_coords, outputs=Y_outputs, params=G_params, mask=M_masks,
-                coords_mean=self.coords_mean,
-                coords_std=self.coords_std,
-                outputs_mean=self.outputs_mean,
-                outputs_std=self.outputs_std,
-                radii_mean=self.radii_mean,
-                radii_std=self.radii_std)
 
     def run_all(self):
         self.load_and_pad()


### PR DESCRIPTION
## Summary
- handle padding once to keep masks aligned
- save preprocessed data including mask only once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848727e7ec48331aae6d16908402e46