### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -22,3 +22,50 @@ def test_trainer_single_epoch():
     trainer = Trainer(model, loader, device="cpu", lr=1e-3)
     train_hist, test_hist = trainer.train(loader, loader, num_epochs=1, print_every=1)
     assert len(train_hist) == len(test_hist) == 1
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, coords, params):
+        batch, n, _ = coords.shape
+        return torch.zeros(batch, n, 1) + self.w
+
+
+def create_mask_loader():
+    coords = torch.zeros(1, 4, 3)
+    params = torch.zeros(1, 1)
+    targets = torch.ones(1, 4, 1)
+    mask = torch.tensor([[1, 0, 1, 0]], dtype=torch.bool)
+    dataset = torch.utils.data.TensorDataset(coords, params, targets, mask)
+    return torch.utils.data.DataLoader(dataset, batch_size=1)
+
+
+def test_evaluate_uses_mask():
+    loader = create_mask_loader()
+    model = DummyModel()
+    trainer = Trainer(model, loader, device="cpu", lr=0.0)
+    loss = trainer.evaluate(loader)
+    expected = ((torch.zeros(4, 1) - torch.ones(4, 1)) ** 2 * torch.tensor([[1, 0, 1, 0]]).unsqueeze(-1)).sum() / 2
+    assert torch.isclose(torch.tensor(loss), expected)
+
+
+def test_train_uses_mask_no_update():
+    loader = create_mask_loader()
+    model = DummyModel()
+    trainer = Trainer(model, loader, device="cpu", lr=0.0)
+    train_hist, _ = trainer.train(loader, loader, num_epochs=1, print_every=1)
+    assert len(train_hist) == 1
+    assert abs(train_hist[0] - trainer.evaluate(loader)) < 1e-6
+
+
+def test_save_and_load_model(tmp_path):
+    loader = create_loaders()
+    model = DummyModel()
+    trainer = Trainer(model, loader, device="cpu", lr=0.0)
+    trainer.save_model(path=str(tmp_path / "m.pt"))
+    model.w.data.fill_(5.0)
+    trainer.load_model(str(tmp_path / "m.pt"))
+    assert torch.allclose(model.w, torch.zeros(1))


### PR DESCRIPTION
## Summary
- add extensive preprocess tests for padding, normalization, saving and LHS
- extend dataloader tests to verify tensor types and dataloader splits
- expand trainer tests to cover evaluate, mask usage and save/load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487e0f07b08331951e036f966c0aea