### PR TITLE
Limit normalization to outputs

### DIFF
--- a/inference/methods_inference.py
+++ b/inference/methods_inference.py
@@ -25,8 +25,8 @@ class MethodsInference:
         }
 
     def _normalize(self, coords, radius):
-        coords = (coords - self.stats["coords_mean"]) / self.stats["coords_std"].float()
-        radius = (radius - self.stats["radii_mean"]) / self.stats["radii_std"].float()
+        # Coordinates and radius were not normalized during training,
+        # so simply return them unchanged
         return coords, radius
 
     def _denormalize(self, output):

--- a/preprocess/methods_preprocess.py
+++ b/preprocess/methods_preprocess.py
@@ -40,22 +40,27 @@ class MethodsPreprocess:
         self.radii = padded_radii
         self.outputs = padded_outputs
 
-        # Normalize AFTER padding
+        # Compute statistics without normalizing coordinates or radii
         coords_flat = np.vstack(self.coords)
         outputs_flat = np.vstack(self.outputs)
         radii_flat = np.vstack(self.radii)
 
-        coords_flat, self.coords_mean, self.coords_std = self._normalize(coords_flat)
-        outputs_flat, self.outputs_mean, self.outputs_std = self._normalize(outputs_flat)
-        radii_flat, self.radii_mean, self.radii_std = self._normalize(radii_flat)
+        # store stats for reference but only normalize flow variables
+        self.coords_mean = np.mean(coords_flat, axis=0)
+        self.coords_std = np.std(coords_flat, axis=0)
+        self.coords_std[self.coords_std == 0] = 1
 
-        # unflatten after the flattening for normalization, 
+        self.radii_mean = np.mean(radii_flat, axis=0)
+        self.radii_std = np.std(radii_flat, axis=0)
+        self.radii_std[self.radii_std == 0] = 1
+
+        outputs_flat, self.outputs_mean, self.outputs_std = self._normalize(outputs_flat)
+
+        # replace outputs with normalized values
         idx = 0
-        for i in range(len(self.coords)):
-            n = self.coords[i].shape[0]
-            self.coords[i] = coords_flat[idx:idx+n]
+        for i in range(len(self.outputs)):
+            n = self.outputs[i].shape[0]
             self.outputs[i] = outputs_flat[idx:idx+n]
-            self.radii[i] = radii_flat[idx:idx+n]
             idx += n
 
     def LHS(self, coords_full, outputs_full): # Latin Hypercube Sampling, 500,000 samples per simulation

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -106,15 +106,13 @@ def test_to_numpy_and_save(preprocess):
     assert data["outputs"].shape == (3, TEST_SAMPLE_SIZE, 5)
     assert data["params"].shape == (3, 1)
 
-    # arrays are normalized
+    # outputs should be normalized
     def check_norm(arr):
         flat = arr.reshape(-1, arr.shape[-1])
         assert np.allclose(flat.mean(axis=0), 0, atol=1e-6)
         assert np.allclose(flat.std(axis=0), 1, atol=1e-6)
 
-    check_norm(data["coords"])
     check_norm(data["outputs"])
-    check_norm(data["params"])
 
 
 def test_lhs_sampling_distribution(preprocess):


### PR DESCRIPTION
## Summary
- only normalize velocity/pressure/density in preprocess
- keep coordinates and radius intact during inference
- adjust tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3e98f70883318726c8383a83d737