### PR TITLE
Add vanilla DeepONet implementation

### DIFF
--- a/preprocess/base_preprocess.py
+++ b/preprocess/base_preprocess.py
@@ -1,6 +1,18 @@
 class BasePreprocess:
-    def __init__(self, ellipse_files, dimension, output_path="processed_data.npz"):
-        self.files = ellipse_files
+    def __init__(self, radius_files, dimension, output_path="processed_data.npz"):
+        """Initialize the preprocessing object.
+
+        Parameters
+        ----------
+        radius_files : dict
+            Mapping from radius value to CSV file path.
+        dimension : int
+            Dimensionality of the data (2 or 3).
+        output_path : str, optional
+            Where the processed ``npz`` file will be written.
+        """
+
+        self.files = radius_files
         self.output_path = output_path
         
         self.coords = []

--- a/preprocess/methods_preprocess.py
+++ b/preprocess/methods_preprocess.py
@@ -5,7 +5,8 @@ from sklearn.neighbors import NearestNeighbors
 
 class MethodsPreprocess:
     def load_and_pad(self):
-        for path in self.files:
+        # ``self.files`` is a mapping from radius value to CSV file path
+        for radius, path in self.files.items():
             df = pd.read_csv(path)
             coords_full = df[["X (m)", "Y (m)", "Z (m)"]].to_numpy()
             outputs_full = df[["Density (kg/m^3)", "Velocity[i] (m/s)", "Velocity[j] (m/s)", "Velocity[k] (m/s)", "Absolute Pressure (Pa)"]].to_numpy()
@@ -15,8 +16,9 @@ class MethodsPreprocess:
             else:
                 coords = coords_full
                 outputs = outputs_full
-            
-            param_vec = df[["a", "b"]].to_numpy()
+
+            # For the vanilla sphere data we only keep the radius as parameter
+            param_vec = np.full((coords.shape[0], 1), radius)
 
             self.coords.append(coords)
             self.radii.append(param_vec)

--- a/tests/test_vanilla_model.py
+++ b/tests/test_vanilla_model.py
@@ -1,0 +1,41 @@
+import pytest
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from vanilla_model import VanillaDeepONet
+import torch
+
+@pytest.fixture
+def model():
+    return VanillaDeepONet(coord_dim=3, param_dim=1, hidden_size=64, num_hidden_layers=3, out_dim=5)
+
+def test_forward_shape(model):
+    coords = torch.rand(2, 100, 3)
+    params = torch.rand(2, 1)
+    out = model(coords, params)
+    assert out.shape == (2, 100, 5)
+
+def test_invalid_input_shape_raises(model):
+    coords = torch.rand(2, 50, 2)
+    params = torch.rand(2, 1)
+    with pytest.raises(RuntimeError):
+        model(coords, params)
+
+def test_output_is_finite(model):
+    coords = torch.rand(2, 50, 3)
+    params = torch.rand(2, 1)
+    out = model(coords, params)
+    assert torch.isfinite(out).all()
+
+def test_repeatable_output(model):
+    torch.manual_seed(42)
+    coords = torch.rand(1, 20, 3)
+    params = torch.rand(1, 1)
+    out1 = model(coords, params)
+
+    torch.manual_seed(42)
+    coords = torch.rand(1, 20, 3)
+    params = torch.rand(1, 1)
+    out2 = model(coords, params)
+
+    assert torch.allclose(out1, out2, atol=1e-5)

--- a/vanilla_model/__init__.py
+++ b/vanilla_model/__init__.py
@@ -1,0 +1,23 @@
+import torch
+from .base_model import BaseModel
+from .methods_model import MethodsModel
+
+class VanillaDeepONet(BaseModel, MethodsModel):
+    def forward(self, coords, params):
+        B, n_pts, _ = coords.shape
+        H = self.hidden_size
+        O = self.out_dim
+
+        branch_out = self.branch(params)
+
+        x = coords
+        for layer, act in zip(self.trunk_layers, self.trunk_activations):
+            x = act(layer(x))
+        trunk_out = self.trunk_final(x)
+
+        branch_out = branch_out.view(B, O, H)
+        trunk_out = trunk_out.view(B, n_pts, 1, H)
+        branch_out = branch_out.unsqueeze(1)
+
+        out = torch.sum(branch_out * trunk_out, dim=-1)
+        return out

--- a/vanilla_model/base_model.py
+++ b/vanilla_model/base_model.py
@@ -1,0 +1,21 @@
+import torch.nn as nn
+from model.MLP import MLP
+from model.activations import RowdyActivation
+
+class BaseModel(nn.Module):
+    def __init__(self, coord_dim, param_dim, hidden_size, num_hidden_layers, out_dim):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.out_dim = out_dim
+        self.num_hidden_layers = num_hidden_layers
+
+        self.branch = MLP(param_dim, hidden_size * out_dim, hidden_size, num_hidden_layers)
+
+        self.trunk_layers = nn.ModuleList([
+            nn.Linear(coord_dim if i == 0 else hidden_size, hidden_size)
+            for i in range(num_hidden_layers)
+        ])
+        self.trunk_activations = nn.ModuleList([
+            RowdyActivation(hidden_size) for _ in range(num_hidden_layers)
+        ])
+        self.trunk_final = nn.Linear(hidden_size, hidden_size)

--- a/vanilla_model/methods_model.py
+++ b/vanilla_model/methods_model.py
@@ -1,0 +1,2 @@
+class MethodsModel:
+    pass


### PR DESCRIPTION
## Summary
- fix Preprocess argument name and handling
- implement a new simplified DeepONet in `vanilla_model`
- add unit tests for the vanilla model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850181bfeb88331978a7b3efa015fe0