### PR TITLE
Fix predicted output path handling

### DIFF
--- a/src/inference/methods_inference.py
+++ b/src/inference/methods_inference.py
@@ -45,7 +45,10 @@ class MethodsInference:
         ]
         # Get the directory of the current script
         current_dir = os.path.dirname(os.path.abspath(__file__))
-        out_path = os.path.join(current_dir, out_path)
+        if out_path is None:
+            out_path = os.path.join(current_dir, "predicted_output.csv")
+        elif not os.path.isabs(out_path):
+            out_path = os.path.join(current_dir, out_path)
         with open(out_path, mode='w', newline='') as f:
             writer = csv.writer(f, quoting=csv.QUOTE_NONNUMERIC)
             writer.writerow(headers)

--- a/src/surrogate/base_surrogate.py
+++ b/src/surrogate/base_surrogate.py
@@ -1,4 +1,5 @@
 import torch
+import os
 class BaseSurrogate:
     def __init__(self, files=None):
 
@@ -20,5 +21,9 @@ class BaseSurrogate:
         self.files = files
         self.loss_history_file_name = "loss_history_test.png"
         self.model_path = "src/model/fusion_deeponet.pt"
-        self.predicted_output_file = "predicted_output.csv"
+        # Save predictions inside the inference module so other modules can
+        # reliably find the output regardless of the current working directory.
+        self.predicted_output_file = os.path.join(
+            os.path.dirname(__file__), "..", "inference", "predicted_output.csv"
+        )
         self.true_data = "Data/ellipse_data/ellipse_data_unseen2.csv"


### PR DESCRIPTION
## Summary
- ensure predicted output is saved within inference module
- handle absolute paths when saving CSV predictions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544d45b05c83319aa64f02bd49a5e1